### PR TITLE
update project to airflow 2.10.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.3.1
+FROM apache/airflow:2.10.4
 
 USER root
 

--- a/README.MD
+++ b/README.MD
@@ -2,25 +2,27 @@
 
 Simple repo showing a boilerplate setup for running an airflow stack using docker compose and an extended airflow container.
 
+**Tested with Apache Airflow 2.10.4**
+
 ## Running the stack
 
-You can run the stack by using the following docker-compose commands.
+You can run the stack by using the following docker compose commands.
 
 ```bash
 # Build the local extended Airflow container using the local Dockerfile
-docker-compose build
+docker compose build
 
 # Run all of the containers used in the stack
-docker-compose up
+docker compose up
 ```
 
-Onc running the stack can be access on [`localhost:8080`](localhost:8080).
+Once running the stack can be accessed on [`localhost:8080`](http://localhost:8080).
 
 If you want to tear down the stack you can use the following command to perform a graceful shutdown.
 
 ```bash
 # Take down the airflow stack gracefully
-docker-compose down
+docker compose down
 ```
 
 ## Development
@@ -42,7 +44,7 @@ You should then configure your code editor to use this venv for sourcing modules
 
 ## Contact
 
-If you have any questions or comments about this feel free to reach out throw an issue on the repo or the contact options below.
+If you have any questions or comments about this feel free to reach out through an issue on the repo or the contact options below.
 
 - [Twitter](https://twitter.com/Aaron_KT_Berry)
 

--- a/dags/project_bar/example_dag.py
+++ b/dags/project_bar/example_dag.py
@@ -9,7 +9,7 @@ import pendulum
 
 with DAG(
     dag_id='project_bar_example_dag',
-    schedule_interval='0 0 * * *',
+    schedule='0 0 * * *',
     start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     catchup=False,
     dagrun_timeout=datetime.timedelta(minutes=60),
@@ -56,6 +56,3 @@ this_will_skip = BashOperator(
 )
 
 this_will_skip >> run_this_last
-
-if __name__ == "__main__":
-    dag.cli()

--- a/dags/project_foo/example_dag.py
+++ b/dags/project_foo/example_dag.py
@@ -7,7 +7,7 @@ import pendulum
 
 with DAG(
     dag_id='project_foo_example_dag',
-    schedule_interval='0 0 * * *',
+    schedule='0 0 * * *',
     start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     catchup=False,
     dagrun_timeout=datetime.timedelta(minutes=60),
@@ -49,6 +49,3 @@ this_will_skip = BashOperator(
     dag=dag,
 )
 this_will_skip >> run_this_last
-
-if __name__ == "__main__":
-    dag.cli()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@
 # The following variables are supported:
 #
 # AIRFLOW_IMAGE_NAME           - Docker image name used to run Airflow.
-#                                Default: apache/airflow:2.3.1
+#                                Default: apache/airflow:2.10.4
 # AIRFLOW_UID                  - User ID in Airflow containers
 #                                Default: 50000
 # Those configurations are useful mostly in case of standalone testing/running Airflow in test/try-out mode
@@ -38,20 +38,17 @@
 #
 # Feel free to modify this file to suit your needs.
 ---
-version: '3'
 x-airflow-common:
   &airflow-common
   # In order to add custom dependencies or upgrade provider packages you can use your extended image.
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
-  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.3.1}
+  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.10.4}
   build: .
   environment:
     &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
-    # For backward compatibility, with Airflow <2.3
-    AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
     AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@postgres/airflow
     AIRFLOW__CELERY__BROKER_URL: redis://:@redis:6379/0
     AIRFLOW__CORE__FERNET_KEY: ''
@@ -72,7 +69,7 @@ x-airflow-common:
 
 services:
   postgres:
-    image: postgres:13
+    image: postgres:16
     environment:
       POSTGRES_USER: airflow
       POSTGRES_PASSWORD: airflow
@@ -86,7 +83,7 @@ services:
     restart: always
 
   redis:
-    image: redis:latest
+    image: redis:7.4
     expose:
       - 6379
     healthcheck:
@@ -116,7 +113,7 @@ services:
     <<: *airflow-common
     command: scheduler
     healthcheck:
-      test: ["CMD-SHELL", 'airflow jobs check --job-type SchedulerJob --hostname "$${HOSTNAME}"']
+      test: ["CMD-SHELL", 'airflow jobs check --job-type Scheduler --hostname "$${HOSTNAME}"']
       interval: 10s
       timeout: 10s
       retries: 5
@@ -151,7 +148,7 @@ services:
     <<: *airflow-common
     command: triggerer
     healthcheck:
-      test: ["CMD-SHELL", 'airflow jobs check --job-type TriggererJob --hostname "$${HOSTNAME}"']
+      test: ["CMD-SHELL", 'airflow jobs check --job-type Triggerer --hostname "$${HOSTNAME}"']
       interval: 10s
       timeout: 10s
       retries: 5
@@ -173,7 +170,7 @@ services:
         }
         airflow_version=$$(gosu airflow airflow version)
         airflow_version_comparable=$$(ver $${airflow_version})
-        min_airflow_version=2.2.0
+        min_airflow_version=2.8.0
         min_airflow_version_comparable=$$(ver $${min_airflow_version})
         if (( airflow_version_comparable < min_airflow_version_comparable )); then
           echo
@@ -230,7 +227,7 @@ services:
     # yamllint enable rule:line-length
     environment:
       <<: *airflow-common-env
-      _AIRFLOW_DB_UPGRADE: 'true'
+      _AIRFLOW_DB_MIGRATE: 'true'
       _AIRFLOW_WWW_USER_CREATE: 'true'
       _AIRFLOW_WWW_USER_USERNAME: ${_AIRFLOW_WWW_USER_USERNAME:-airflow}
       _AIRFLOW_WWW_USER_PASSWORD: ${_AIRFLOW_WWW_USER_PASSWORD:-airflow}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-awscli
-requests
-beautifulsoup4
-pendulum
-apache-airflow
+awscli>=1.30.0
+requests>=2.31.0
+beautifulsoup4>=4.12.0
+pendulum>=3.0.0


### PR DESCRIPTION
This pull request updates the boilerplate Airflow stack to use newer versions of Airflow and its dependencies, improves documentation, and makes minor DAG and configuration cleanups. The main focus is on upgrading to Apache Airflow 2.10.4 and modernizing the Docker Compose setup.

**Dependency and configuration upgrades:**

* Updated base Airflow image in `Dockerfile` and `docker-compose.yaml` from `apache/airflow:2.3.1` to `apache/airflow:2.10.4`, and changed the default Postgres and Redis images to `postgres:16` and `redis:7.4` respectively for improved stability and compatibility. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1) [[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L41-L54) [[3]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L75-R72) [[4]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L89-R86)
* Changed Airflow healthcheck commands in `docker-compose.yaml` to use the new job type names (`Scheduler` and `Triggerer`) for compatibility with Airflow 2.10+. [[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L119-R116) [[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L154-R151)
* Updated minimum required Airflow version in the setup script to 2.8.0, ensuring the stack only runs with supported versions.
* Replaced the environment variable `_AIRFLOW_DB_UPGRADE` with `_AIRFLOW_DB_MIGRATE` in `docker-compose.yaml` to match updated Airflow conventions.

**Documentation improvements:**

* Updated `README.MD` to reflect testing with Airflow 2.10.4, clarified instructions to use the modern `docker compose` commands, fixed typos, and improved the localhost access link. [[1]](diffhunk://#diff-01e6d9ffed056a02cae8d8a0ec5d476a64d017bf85c0d5a94bb23ca21f33f5aaR5-R25) [[2]](diffhunk://#diff-01e6d9ffed056a02cae8d8a0ec5d476a64d017bf85c0d5a94bb23ca21f33f5aaL45-R47)

**DAG file cleanups:**

* Replaced deprecated `schedule_interval` argument with `schedule` in both example DAGs for Airflow 2.10+ compatibility. [[1]](diffhunk://#diff-9f0e65b0b36ef9d96f606b0b6dcf3f9d46630f1acbf45c5e0560e60fc567bd8bL12-R12) [[2]](diffhunk://#diff-95ff73d3d737cda76c85209695fe8eb36ad07fbce5f9b4601bcab5e1e7af7cd4L10-R10)
* Removed unnecessary CLI code from the bottom of both example DAG files for cleaner DAG definitions. [[1]](diffhunk://#diff-9f0e65b0b36ef9d96f606b0b6dcf3f9d46630f1acbf45c5e0560e60fc567bd8bL59-L61) [[2]](diffhunk://#diff-95ff73d3d737cda76c85209695fe8eb36ad07fbce5f9b4601bcab5e1e7af7cd4L52-L54)